### PR TITLE
Mock package

### DIFF
--- a/mock/client.go
+++ b/mock/client.go
@@ -59,10 +59,6 @@ func (m *Client) Call(methodName string, args ...interface{}) (v xmlrpc.Value, e
 		}
 	}
 
-	if m.Testing.Failed() {
-		m.Testing.FailNow()
-	}
-
 	return m.CallMock(methodName, args...)
 }
 

--- a/mock/client.go
+++ b/mock/client.go
@@ -23,6 +23,10 @@ func NewClient(t *testing.T) *Client {
 }
 
 func (m *Client) Call(methodName string, args ...interface{}) (v xmlrpc.Value, err error) {
+	if m.Testing == nil {
+		return m.CallMock(methodName, args...)
+	}
+
 	if m.expectedMethodName != nil {
 		m.expectedMethodName(m.Testing, methodName)
 	}

--- a/mock/client.go
+++ b/mock/client.go
@@ -49,6 +49,12 @@ func (m *Client) Call(methodName string, args ...interface{}) (v xmlrpc.Value, e
 
 	if m.expectedArguments != nil {
 		for i, f := range m.expectedArguments {
+			if len(args) <= i {
+				m.Testing.Errorf("args[%d] is missing", i)
+
+				break
+			}
+
 			f(m.Testing, args[i])
 		}
 	}

--- a/mock/client.go
+++ b/mock/client.go
@@ -16,6 +16,12 @@ type Client struct {
 	expectedArguments     map[int]func(t *testing.T, actual interface{})
 }
 
+func NewClient(t *testing.T) *Client {
+	return &Client{
+		Testing: t,
+	}
+}
+
 func (m *Client) Call(methodName string, args ...interface{}) (v xmlrpc.Value, err error) {
 	if m.expectedMethodName != nil {
 		m.expectedMethodName(m.Testing, methodName)
@@ -64,4 +70,18 @@ func (m *Client) ExpectArgument(index int, kind reflect.Kind, expected interface
 			t.Errorf("args[%d] == %q, want %q", index, actual, expected)
 		}
 	}
+}
+
+func (m *Client) WithValue(value xmlrpc.Value) *Client {
+	m.CallMock = func(methodName string, args ...interface{}) (xmlrpc.Value, error) {
+		return value, nil
+	}
+	return m
+}
+
+func (m *Client) WithError(err error) *Client {
+	m.CallMock = func(methodName string, args ...interface{}) (xmlrpc.Value, error) {
+		return nil, err
+	}
+	return m
 }

--- a/mock/client.go
+++ b/mock/client.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-type mockClient struct {
+type Client struct {
 	CallMock func(methodName string, args ...interface{}) (xmlrpc.Value, error)
 
 	Testing *testing.T
@@ -16,7 +16,7 @@ type mockClient struct {
 	expectedArguments     map[int]func(t *testing.T, actual interface{})
 }
 
-func (m *mockClient) Call(methodName string, args ...interface{}) (v xmlrpc.Value, err error) {
+func (m *Client) Call(methodName string, args ...interface{}) (v xmlrpc.Value, err error) {
 	if m.expectedMethodName != nil {
 		m.expectedMethodName(m.Testing, methodName)
 	}
@@ -38,7 +38,7 @@ func (m *mockClient) Call(methodName string, args ...interface{}) (v xmlrpc.Valu
 	return m.CallMock(methodName, args...)
 }
 
-func (m *mockClient) ExpectMethodName(expected string) {
+func (m *Client) ExpectMethodName(expected string) {
 	m.expectedMethodName = func(t *testing.T, actual string) {
 		if actual != expected {
 			t.Errorf("methodName == %q, want %q", actual, expected)
@@ -46,7 +46,7 @@ func (m *mockClient) ExpectMethodName(expected string) {
 	}
 }
 
-func (m *mockClient) ExpectArgumentCount(expected int) {
+func (m *Client) ExpectArgumentCount(expected int) {
 	m.expectedArgumentCount = func(t *testing.T, actual int) {
 		if actual != expected {
 			t.Errorf("len(args) == %v, want %v", actual, expected)
@@ -54,7 +54,7 @@ func (m *mockClient) ExpectArgumentCount(expected int) {
 	}
 }
 
-func (m *mockClient) ExpectArgument(index int, kind reflect.Kind, expected interface{}) {
+func (m *Client) ExpectArgument(index int, kind reflect.Kind, expected interface{}) {
 	if m.expectedArguments == nil {
 		m.expectedArguments = make(map[int]func(t *testing.T, actual interface{}))
 	}

--- a/mock/client.go
+++ b/mock/client.go
@@ -1,0 +1,67 @@
+package mock
+
+import (
+	"github.com/SHyx0rmZ/go-xmlrpc"
+	"reflect"
+	"testing"
+)
+
+type mockClient struct {
+	CallMock func(methodName string, args ...interface{}) (xmlrpc.Value, error)
+
+	Testing *testing.T
+
+	expectedMethodName    func(t *testing.T, actual string)
+	expectedArgumentCount func(t *testing.T, actual int)
+	expectedArguments     map[int]func(t *testing.T, actual interface{})
+}
+
+func (m *mockClient) Call(methodName string, args ...interface{}) (v xmlrpc.Value, err error) {
+	if m.expectedMethodName != nil {
+		m.expectedMethodName(m.Testing, methodName)
+	}
+
+	if m.expectedArgumentCount != nil {
+		m.expectedArgumentCount(m.Testing, len(args))
+	}
+
+	if m.expectedArguments != nil {
+		for i, f := range m.expectedArguments {
+			f(m.Testing, args[i])
+		}
+	}
+
+	if m.Testing.Failed() {
+		m.Testing.FailNow()
+	}
+
+	return m.CallMock(methodName, args...)
+}
+
+func (m *mockClient) ExpectMethodName(expected string) {
+	m.expectedMethodName = func(t *testing.T, actual string) {
+		if actual != expected {
+			t.Errorf("methodName == %q, want %q", actual, expected)
+		}
+	}
+}
+
+func (m *mockClient) ExpectArgumentCount(expected int) {
+	m.expectedArgumentCount = func(t *testing.T, actual int) {
+		if actual != expected {
+			t.Errorf("len(args) == %v, want %v", actual, expected)
+		}
+	}
+}
+
+func (m *mockClient) ExpectArgument(index int, kind reflect.Kind, expected interface{}) {
+	if m.expectedArguments == nil {
+		m.expectedArguments = make(map[int]func(t *testing.T, actual interface{}))
+	}
+
+	m.expectedArguments[index] = func(t *testing.T, actual interface{}) {
+		if reflect.ValueOf(actual).Kind() != kind || actual != expected {
+			t.Errorf("args[%d] == %q, want %q", index, actual, expected)
+		}
+	}
+}

--- a/mock/client_test.go
+++ b/mock/client_test.go
@@ -1,0 +1,181 @@
+package mock_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"errors"
+	"github.com/SHyx0rmZ/go-xmlrpc"
+	"github.com/SHyx0rmZ/go-xmlrpc/mock"
+	"reflect"
+	"testing"
+	"time"
+)
+
+var _ = Describe("mock Client", func() {
+
+	Context("nil Testing", func() {
+		var (
+			client *mock.Client
+		)
+
+		BeforeEach(func() {
+			client = mock.NewClient(nil)
+		})
+
+		Context("setting func", func() {
+			It("calls the CallMock", func() {
+				value := mock.NewValue()
+
+				client.CallMock = func(methodName string, args ...interface{}) (xmlrpc.Value, error) {
+					Expect(methodName).To(Equal("test-method"))
+					Expect(args).To(HaveLen(3))
+					Expect(args).To(ConsistOf("foo", 42, true))
+
+					return value, nil
+				}
+
+				v, err := client.Call("test-method", "foo", 42, true)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(v).To(BeIdenticalTo(value))
+			})
+		})
+
+		Context("using method", func() {
+			Context("WithValue", func() {
+				It("returns the Value", func() {
+					value := mock.NewValue()
+
+					client.WithValue(value)
+
+					v, err := client.Call("test-method")
+
+					Expect(err).ToNot(HaveOccurred())
+					Expect(v).To(BeIdenticalTo(value))
+				})
+			})
+
+			Context("WithError", func() {
+				It("returns the error", func() {
+					client.WithError(errors.New("test-error"))
+
+					v, err := client.Call("test-method")
+
+					Expect(err).To(HaveOccurred())
+					Expect(v).To(BeNil())
+				})
+			})
+		})
+
+		It("won't assert expectations about the methodName", func() {
+			client.ExpectMethodName("test-method-not-expected")
+
+			client.WithValue(nil)
+
+			Expect(client.Call("test-method")).To(BeNil())
+		})
+
+		It("won't assert expectations about the number of args", func() {
+			client.ExpectArgumentCount(3)
+
+			client.WithValue(nil)
+
+			Expect(client.Call("test-method")).To(BeNil())
+		})
+
+		It("won't assert expectations about a specific arg", func() {
+			client.ExpectArgument(0, reflect.String, "test-arg-not-expected")
+
+			client.WithValue(nil)
+
+			Expect(client.Call("test-method")).To(BeNil())
+		})
+	})
+
+	Context("non-nil Testing", func() {
+		var (
+			client *mock.Client
+		)
+
+		BeforeEach(func() {
+			client = mock.NewClient(&testing.T{})
+		})
+
+		Context("will assert expectations about the methodName", func() {
+			Context("methodName matches", func() {
+				It("will not modify Testing", func() {
+					client.ExpectMethodName("test-method")
+
+					client.WithValue(nil)
+
+					Expect(client.Call("test-method")).To(BeNil())
+					Expect(client.Testing.Failed()).To(BeFalse())
+				})
+			})
+
+			Context("methodName doesn't match", func() {
+				It("will modifiy Testing", func() {
+					client.ExpectMethodName("test-method-not-expected")
+
+					client.WithValue(nil)
+
+					Expect(client.Call("test-method")).To(BeNil())
+					Expect(client.Testing.Failed()).To(BeTrue())
+				})
+			})
+		})
+
+		Context("will assert expectations about the number of args", func() {
+			Context("number of args matches", func() {
+				It("will not modifiy Testing", func() {
+					client.ExpectArgumentCount(3)
+
+					client.WithValue(nil)
+
+					Expect(client.Call("test-method", "foo", 42, true)).To(BeNil())
+					Expect(client.Testing.Failed()).To(BeFalse())
+				})
+			})
+
+			Context("number of args doesn't match", func() {
+				It("will modifiy Testing", func() {
+					client.ExpectArgumentCount(7)
+
+					client.WithValue(nil)
+
+					Expect(client.Call("test-method", "foo", 42, true)).To(BeNil())
+					Expect(client.Testing.Failed()).To(BeTrue())
+				})
+			})
+		})
+
+		Context("will assert expectations about specific args", func() {
+			Context("specific args match", func() {
+				It("will not modifiy Testing", func() {
+					client.ExpectArgument(0, reflect.String, "foo")
+					client.ExpectArgument(1, reflect.Int, 42)
+					client.ExpectArgument(2, reflect.Bool, true)
+
+					client.WithValue(nil)
+
+					Expect(client.Call("test-method", "foo", 42, true)).To(BeNil())
+					Expect(client.Testing.Failed()).To(BeFalse())
+				})
+			})
+
+			Context("specific args don't match", func() {
+				It("will modify Testing", func() {
+					client.ExpectArgument(0, reflect.String, "foo")
+					client.ExpectArgument(1, reflect.Int, 42)
+					client.ExpectArgument(2, reflect.Bool, true)
+
+					client.WithValue(nil)
+
+					Expect(client.Call("test-method", 8.25, time.Now())).To(BeNil())
+					Expect(client.Testing.Failed()).To(BeTrue())
+				})
+			})
+		})
+	})
+})

--- a/mock/member.go
+++ b/mock/member.go
@@ -2,15 +2,15 @@ package mock
 
 import "github.com/SHyx0rmZ/go-xmlrpc"
 
-type mockMember struct {
+type Member struct {
 	NameMock  func() string
 	ValueMock func() xmlrpc.Value
 }
 
-func (m *mockMember) Name() string {
+func (m *Member) Name() string {
 	return m.NameMock()
 }
 
-func (m *mockMember) Value() xmlrpc.Value {
+func (m *Member) Value() xmlrpc.Value {
 	return m.ValueMock()
 }

--- a/mock/member.go
+++ b/mock/member.go
@@ -1,0 +1,16 @@
+package mock
+
+import "github.com/SHyx0rmZ/go-xmlrpc"
+
+type mockMember struct {
+	NameMock  func() string
+	ValueMock func() xmlrpc.Value
+}
+
+func (m *mockMember) Name() string {
+	return m.NameMock()
+}
+
+func (m *mockMember) Value() xmlrpc.Value {
+	return m.ValueMock()
+}

--- a/mock/member.go
+++ b/mock/member.go
@@ -7,10 +7,28 @@ type Member struct {
 	ValueMock func() xmlrpc.Value
 }
 
+func NewMember() *Member {
+	return &Member{}
+}
+
 func (m *Member) Name() string {
 	return m.NameMock()
 }
 
 func (m *Member) Value() xmlrpc.Value {
 	return m.ValueMock()
+}
+
+func (m *Member) WithName(value string) *Member {
+	m.NameMock = func() string {
+		return value
+	}
+	return m
+}
+
+func (m *Member) WithValue(value xmlrpc.Value) *Member {
+	m.ValueMock = func() xmlrpc.Value {
+		return value
+	}
+	return m
 }

--- a/mock/member.go
+++ b/mock/member.go
@@ -14,6 +14,7 @@ type Member struct {
 // it did have an empty name and contained an invalid xmlrpc.Value.
 func NewMember() *Member {
 	m := &Member{}
+	m.WithName("")
 	m.WithValue(NewValue())
 	return m
 }

--- a/mock/member.go
+++ b/mock/member.go
@@ -2,35 +2,44 @@ package mock
 
 import "github.com/SHyx0rmZ/go-xmlrpc"
 
+// Member is a mock object for xmlrpc.Member.
 type Member struct {
-	NameMock  func() string
+	// NameMock will be invoked every time Name() is called.
+	NameMock func() string
+	// ValueMock will be invoked every time Value() is called.
 	ValueMock func() xmlrpc.Value
 }
 
+// NewMember returns a new mock object for xmlrpc.Member, which will act as if
+// it did have an empty name and contained an invalid xmlrpc.Value.
 func NewMember() *Member {
 	m := &Member{}
 	m.WithValue(NewValue())
 	return m
 }
 
+// Name invokes NameMock and returns its result.
 func (m *Member) Name() string {
 	return m.NameMock()
 }
 
+// Value invokes ValueMock and returns its result.
 func (m *Member) Value() xmlrpc.Value {
 	return m.ValueMock()
 }
 
-func (m *Member) WithName(value string) *Member {
+// WithName assigns a func to NameMock. The func in NameMock will return v.
+func (m *Member) WithName(v string) *Member {
 	m.NameMock = func() string {
-		return value
+		return v
 	}
 	return m
 }
 
-func (m *Member) WithValue(value xmlrpc.Value) *Member {
+// WithValue assigns a func to ValueMock. The func in ValueMock will return v.
+func (m *Member) WithValue(v xmlrpc.Value) *Member {
 	m.ValueMock = func() xmlrpc.Value {
-		return value
+		return v
 	}
 	return m
 }

--- a/mock/member.go
+++ b/mock/member.go
@@ -8,7 +8,9 @@ type Member struct {
 }
 
 func NewMember() *Member {
-	return &Member{}
+	m := &Member{}
+	m.WithValue(NewValue())
+	return m
 }
 
 func (m *Member) Name() string {

--- a/mock/member_test.go
+++ b/mock/member_test.go
@@ -1,0 +1,49 @@
+package mock_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/SHyx0rmZ/go-xmlrpc"
+	"github.com/SHyx0rmZ/go-xmlrpc/mock"
+)
+
+var _ = Describe("Mock member", func() {
+	var (
+		member *mock.Member
+	)
+
+	BeforeEach(func() {
+		member = mock.NewMember()
+	})
+
+	Context("if unmodified", func() {
+		It("returns an empty name", func() {
+			Expect(member.Name()).To(Equal(""))
+		})
+
+		It("returns an invalid value", func() {
+			Expect(member.Value().Kind()).To(Equal(xmlrpc.Invalid))
+		})
+	})
+
+	Context("if modified", func() {
+		It("calls the NameMock", func() {
+			member.NameMock = func() string {
+				return "test-name"
+			}
+
+			Expect(member.Name()).To(Equal("test-name"))
+		})
+
+		It("calls the ValueMock", func() {
+			value := mock.NewValue()
+
+			member.ValueMock = func() xmlrpc.Value {
+				return value
+			}
+
+			Expect(member.Value()).To(BeIdenticalTo(value))
+		})
+	})
+})

--- a/mock/mock_suite_test.go
+++ b/mock/mock_suite_test.go
@@ -1,0 +1,12 @@
+package mock_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestMock(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mock Suite")
+}

--- a/mock/value.go
+++ b/mock/value.go
@@ -135,7 +135,7 @@ func (m *Value) WithMembers(v map[string]xmlrpc.Value) *Value {
 }
 
 func (Value) membersFromMap(vs map[string]xmlrpc.Value) []xmlrpc.Member {
-	m := make([]xmlrpc.Member, len(vs))
+	m := make([]xmlrpc.Member, 0, len(vs))
 	for n, v := range vs {
 		m = append(m, NewMember().WithName(n).WithValue(v))
 	}

--- a/mock/value.go
+++ b/mock/value.go
@@ -5,79 +5,132 @@ import (
 	"time"
 )
 
+// Value is a mock object for xmlrpc.Value.
 type Value struct {
-	ValuesMock  func() []xmlrpc.Value
-	BytesMock   func() []byte
-	BoolMock    func() bool
-	TimeMock    func() time.Time
-	DoubleMock  func() float64
-	IntMock     func() int
-	StringMock  func() string
+	// ValuesMock will be invoked every time Values() is called.
+	ValuesMock func() []xmlrpc.Value
+
+	// BytesMock will be invoked every time Bytes() is called.
+	BytesMock func() []byte
+
+	// BoolMock will be invoked every time Bool() is called.
+	BoolMock func() bool
+
+	// TimeMock will be invoked every time Time() is called.
+	TimeMock func() time.Time
+
+	// DoubleMock will be invoked every time Double() is called.
+	DoubleMock func() float64
+
+	// IntMock will be invoked every time Int() is called.
+	IntMock func() int
+
+	// StringMock will be invoked every time String() is called.
+	StringMock func() string
+
+	// MembersMock will be invoked every time Members() is called.
 	MembersMock func() []xmlrpc.Member
-	KindMock    func() xmlrpc.Kind
+
+	// KindMock will be invoked every time Kind() is called.
+	KindMock func() xmlrpc.Kind
 }
 
+// NewValue returns a new mock object for xmlrpc.Value, which will act as if
+// it were of an invalid kind.
 func NewValue() *Value {
 	return &Value{
 		KindMock: func() xmlrpc.Kind { return xmlrpc.Invalid },
 	}
 }
 
-func (m *Value) Values() []xmlrpc.Value   { return m.ValuesMock() }
-func (m *Value) Bytes() []byte            { return m.BytesMock() }
-func (m *Value) Bool() bool               { return m.BoolMock() }
-func (m *Value) Time() time.Time          { return m.TimeMock() }
-func (m *Value) Double() float64          { return m.DoubleMock() }
-func (m *Value) Int() int                 { return m.IntMock() }
-func (m *Value) String() string           { return m.StringMock() }
+// Values invokes ValuesMock and returns its result.
+func (m *Value) Values() []xmlrpc.Value { return m.ValuesMock() }
+
+// Bytes invokes BytesMock and returns its result.
+func (m *Value) Bytes() []byte { return m.BytesMock() }
+
+// Bool invokes BoolMock and returns its result.
+func (m *Value) Bool() bool { return m.BoolMock() }
+
+// Time invokes TimeMock and returns its result.
+func (m *Value) Time() time.Time { return m.TimeMock() }
+
+// Double invokes DoubleMock and returns its result.
+func (m *Value) Double() float64 { return m.DoubleMock() }
+
+// Int invokes IntMock and returns its result.
+func (m *Value) Int() int { return m.IntMock() }
+
+// String invokes StringMock and returns its result.
+func (m *Value) String() string { return m.StringMock() }
+
+// Members invokes MembersMock and returns its result.
 func (m *Value) Members() []xmlrpc.Member { return m.MembersMock() }
-func (m *Value) Kind() xmlrpc.Kind        { return m.KindMock() }
 
-func (m *Value) WithValues(actual ...xmlrpc.Value) *Value {
+// Kind invokes KindMock and returns its result.
+func (m *Value) Kind() xmlrpc.Kind { return m.KindMock() }
+
+// WithValues assigns funcs to KindMock and ValuesMock. The func in KindMock
+// will return xmlrpc.Array, whereas the func in ValuesMock will return v.
+func (m *Value) WithValues(v ...xmlrpc.Value) *Value {
 	m.KindMock = func() xmlrpc.Kind { return xmlrpc.Array }
-	m.ValuesMock = func() []xmlrpc.Value { return actual }
+	m.ValuesMock = func() []xmlrpc.Value { return v }
 	return m
 }
 
-func (m *Value) WithBytes(actual []byte) *Value {
+// WithBytes assigns funcs to KindMock and BytesMock. The func in KindMock
+// will return xmlrpc.Base64, whereas the func in BytesMock will return v.
+func (m *Value) WithBytes(v []byte) *Value {
 	m.KindMock = func() xmlrpc.Kind { return xmlrpc.Base64 }
-	m.BytesMock = func() []byte { return actual }
+	m.BytesMock = func() []byte { return v }
 	return m
 }
 
-func (m *Value) WithBool(actual bool) *Value {
+// WithBool assigns funcs to KindMock and BoolMock. The func in KindMock will
+// return xmlrpc.Bool, whereas the func in BoolMock will return v.
+func (m *Value) WithBool(v bool) *Value {
 	m.KindMock = func() xmlrpc.Kind { return xmlrpc.Bool }
-	m.BoolMock = func() bool { return actual }
+	m.BoolMock = func() bool { return v }
 	return m
 }
 
-func (m *Value) WithTime(actual time.Time) *Value {
+// WithTime assigns funcs to KindMock and TimeMock. The func in KindMock will
+// return xmlrpc.DateTime, whereas the func in TimeMock will return v.
+func (m *Value) WithTime(v time.Time) *Value {
 	m.KindMock = func() xmlrpc.Kind { return xmlrpc.DateTime }
-	m.TimeMock = func() time.Time { return actual }
+	m.TimeMock = func() time.Time { return v }
 	return m
 }
 
-func (m *Value) WithDouble(actual float64) *Value {
+// WithDouble assigns funcs to KindMock and DoubleMock. The func in KindMock
+// will return xmlrpc.Double, whereas the func in DoubleMock will return v.
+func (m *Value) WithDouble(v float64) *Value {
 	m.KindMock = func() xmlrpc.Kind { return xmlrpc.Double }
-	m.DoubleMock = func() float64 { return actual }
+	m.DoubleMock = func() float64 { return v }
 	return m
 }
 
-func (m *Value) WithInt(actual int) *Value {
+// WithInt assigns funcs to KindMock and IntMock. The func in KindMock will
+// return xmlrpc.Int, whereas the func in IntMock will return v.
+func (m *Value) WithInt(v int) *Value {
 	m.KindMock = func() xmlrpc.Kind { return xmlrpc.Int }
-	m.IntMock = func() int { return actual }
+	m.IntMock = func() int { return v }
 	return m
 }
 
-func (m *Value) WithString(actual string) *Value {
+// WithString assigns funcs to KindMock and StringMock. The func in KindMock
+// will return xmlrpc.String, whereas the func in StringMock will return v.
+func (m *Value) WithString(v string) *Value {
 	m.KindMock = func() xmlrpc.Kind { return xmlrpc.String }
-	m.StringMock = func() string { return actual }
+	m.StringMock = func() string { return v }
 	return m
 }
 
-func (m *Value) WithMembers(actual map[string]xmlrpc.Value) *Value {
+// WithMembers assigns funcs to KindMock and MembersMock. The func in KindMock
+// will return xmlrpc.Struct, whereas the func in MembersMock will return v.
+func (m *Value) WithMembers(v map[string]xmlrpc.Value) *Value {
 	m.KindMock = func() xmlrpc.Kind { return xmlrpc.Struct }
-	m.MembersMock = func() []xmlrpc.Member { return m.membersFromMap(actual) }
+	m.MembersMock = func() []xmlrpc.Member { return m.membersFromMap(v) }
 	return m
 }
 

--- a/mock/value.go
+++ b/mock/value.go
@@ -84,10 +84,7 @@ func (m *Value) WithMembers(actual map[string]xmlrpc.Value) *Value {
 func (Value) membersFromMap(vs map[string]xmlrpc.Value) []xmlrpc.Member {
 	m := make([]xmlrpc.Member, len(vs))
 	for n, v := range vs {
-		m = append(m, &Member{
-			NameMock:  func() string { return n },
-			ValueMock: func() xmlrpc.Value { return v },
-		})
+		m = append(m, NewMember().WithName(n).WithValue(v))
 	}
 	return m
 }

--- a/mock/value.go
+++ b/mock/value.go
@@ -1,0 +1,91 @@
+package mock
+
+import (
+	"github.com/SHyx0rmZ/go-xmlrpc"
+	"time"
+)
+
+type mockValue struct {
+	ValuesMock  func() []xmlrpc.Value
+	BytesMock   func() []byte
+	BoolMock    func() bool
+	TimeMock    func() time.Time
+	DoubleMock  func() float64
+	IntMock     func() int
+	StringMock  func() string
+	MembersMock func() []xmlrpc.Member
+	KindMock    func() xmlrpc.Kind
+}
+
+func (m *mockValue) Values() []xmlrpc.Value   { return m.ValuesMock() }
+func (m *mockValue) Bytes() []byte            { return m.BytesMock() }
+func (m *mockValue) Bool() bool               { return m.BoolMock() }
+func (m *mockValue) Time() time.Time          { return m.TimeMock() }
+func (m *mockValue) Double() float64          { return m.DoubleMock() }
+func (m *mockValue) Int() int                 { return m.IntMock() }
+func (m *mockValue) String() string           { return m.StringMock() }
+func (m *mockValue) Members() []xmlrpc.Member { return m.MembersMock() }
+func (m *mockValue) Kind() xmlrpc.Kind        { return m.KindMock() }
+
+func MockValueReturningValues(actual ...xmlrpc.Value) *mockValue {
+	return &mockValue{
+		KindMock:   func() xmlrpc.Kind { return xmlrpc.Array },
+		ValuesMock: func() []xmlrpc.Value { return actual },
+	}
+}
+
+func MockValueReturningBytes(actual []byte) *mockValue {
+	return &mockValue{
+		KindMock:  func() xmlrpc.Kind { return xmlrpc.Base64 },
+		BytesMock: func() []byte { return actual },
+	}
+}
+
+func MockValueReturningBool(actual bool) *mockValue {
+	return &mockValue{
+		KindMock: func() xmlrpc.Kind { return xmlrpc.Bool },
+		BoolMock: func() bool { return actual },
+	}
+}
+
+func MockValueReturningTime(actual time.Time) *mockValue {
+	return &mockValue{
+		KindMock: func() xmlrpc.Kind { return xmlrpc.DateTime },
+		TimeMock: func() time.Time { return actual },
+	}
+}
+
+func MockValueReturningDouble(actual float64) *mockValue {
+	return &mockValue{
+		KindMock:   func() xmlrpc.Kind { return xmlrpc.Double },
+		DoubleMock: func() float64 { return actual },
+	}
+}
+
+func MockValueReturningInt(actual int) *mockValue {
+	return &mockValue{
+		KindMock: func() xmlrpc.Kind { return xmlrpc.Int },
+		IntMock:  func() int { return actual },
+	}
+}
+
+func MockValueReturningString(actual string) *mockValue {
+	return &mockValue{
+		KindMock:   func() xmlrpc.Kind { return xmlrpc.String },
+		StringMock: func() string { return actual },
+	}
+}
+
+func MockValueReturningMembers(actual map[string]xmlrpc.Value) *mockValue {
+	members := make([]xmlrpc.Member, 0)
+	for name, value := range actual {
+		members = append(members, &mockMember{
+			NameMock:  func() string { return name },
+			ValueMock: func() xmlrpc.Value { return value },
+		})
+	}
+	return &mockValue{
+		KindMock:    func() xmlrpc.Kind { return xmlrpc.Struct },
+		MembersMock: func() []xmlrpc.Member { return members },
+	}
+}

--- a/mock/value.go
+++ b/mock/value.go
@@ -17,6 +17,12 @@ type Value struct {
 	KindMock    func() xmlrpc.Kind
 }
 
+func NewValue() *Value {
+	return &Value{
+		KindMock: func() xmlrpc.Kind { return xmlrpc.Invalid },
+	}
+}
+
 func (m *Value) Values() []xmlrpc.Value   { return m.ValuesMock() }
 func (m *Value) Bytes() []byte            { return m.BytesMock() }
 func (m *Value) Bool() bool               { return m.BoolMock() }

--- a/mock/value.go
+++ b/mock/value.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-type mockValue struct {
+type Value struct {
 	ValuesMock  func() []xmlrpc.Value
 	BytesMock   func() []byte
 	BoolMock    func() bool
@@ -17,75 +17,75 @@ type mockValue struct {
 	KindMock    func() xmlrpc.Kind
 }
 
-func (m *mockValue) Values() []xmlrpc.Value   { return m.ValuesMock() }
-func (m *mockValue) Bytes() []byte            { return m.BytesMock() }
-func (m *mockValue) Bool() bool               { return m.BoolMock() }
-func (m *mockValue) Time() time.Time          { return m.TimeMock() }
-func (m *mockValue) Double() float64          { return m.DoubleMock() }
-func (m *mockValue) Int() int                 { return m.IntMock() }
-func (m *mockValue) String() string           { return m.StringMock() }
-func (m *mockValue) Members() []xmlrpc.Member { return m.MembersMock() }
-func (m *mockValue) Kind() xmlrpc.Kind        { return m.KindMock() }
+func (m *Value) Values() []xmlrpc.Value   { return m.ValuesMock() }
+func (m *Value) Bytes() []byte            { return m.BytesMock() }
+func (m *Value) Bool() bool               { return m.BoolMock() }
+func (m *Value) Time() time.Time          { return m.TimeMock() }
+func (m *Value) Double() float64          { return m.DoubleMock() }
+func (m *Value) Int() int                 { return m.IntMock() }
+func (m *Value) String() string           { return m.StringMock() }
+func (m *Value) Members() []xmlrpc.Member { return m.MembersMock() }
+func (m *Value) Kind() xmlrpc.Kind        { return m.KindMock() }
 
-func MockValueReturningValues(actual ...xmlrpc.Value) *mockValue {
-	return &mockValue{
+func ValueReturningValues(actual ...xmlrpc.Value) *Value {
+	return &Value{
 		KindMock:   func() xmlrpc.Kind { return xmlrpc.Array },
 		ValuesMock: func() []xmlrpc.Value { return actual },
 	}
 }
 
-func MockValueReturningBytes(actual []byte) *mockValue {
-	return &mockValue{
+func ValueReturningBytes(actual []byte) *Value {
+	return &Value{
 		KindMock:  func() xmlrpc.Kind { return xmlrpc.Base64 },
 		BytesMock: func() []byte { return actual },
 	}
 }
 
-func MockValueReturningBool(actual bool) *mockValue {
-	return &mockValue{
+func ValueReturningBool(actual bool) *Value {
+	return &Value{
 		KindMock: func() xmlrpc.Kind { return xmlrpc.Bool },
 		BoolMock: func() bool { return actual },
 	}
 }
 
-func MockValueReturningTime(actual time.Time) *mockValue {
-	return &mockValue{
+func ValueReturningTime(actual time.Time) *Value {
+	return &Value{
 		KindMock: func() xmlrpc.Kind { return xmlrpc.DateTime },
 		TimeMock: func() time.Time { return actual },
 	}
 }
 
-func MockValueReturningDouble(actual float64) *mockValue {
-	return &mockValue{
+func ValueReturningDouble(actual float64) *Value {
+	return &Value{
 		KindMock:   func() xmlrpc.Kind { return xmlrpc.Double },
 		DoubleMock: func() float64 { return actual },
 	}
 }
 
-func MockValueReturningInt(actual int) *mockValue {
-	return &mockValue{
+func ValueReturningInt(actual int) *Value {
+	return &Value{
 		KindMock: func() xmlrpc.Kind { return xmlrpc.Int },
 		IntMock:  func() int { return actual },
 	}
 }
 
-func MockValueReturningString(actual string) *mockValue {
-	return &mockValue{
+func ValueReturningString(actual string) *Value {
+	return &Value{
 		KindMock:   func() xmlrpc.Kind { return xmlrpc.String },
 		StringMock: func() string { return actual },
 	}
 }
 
-func MockValueReturningMembers(actual map[string]xmlrpc.Value) *mockValue {
-	members := make([]xmlrpc.Member, 0)
-	for name, value := range actual {
-		members = append(members, &mockMember{
-			NameMock:  func() string { return name },
-			ValueMock: func() xmlrpc.Value { return value },
+func ValueReturningMembers(actual map[string]xmlrpc.Value) *Value {
+	m := make([]xmlrpc.Member, 0)
+	for n, v := range actual {
+		m = append(m, &Member{
+			NameMock:  func() string { return n },
+			ValueMock: func() xmlrpc.Value { return v },
 		})
 	}
-	return &mockValue{
+	return &Value{
 		KindMock:    func() xmlrpc.Kind { return xmlrpc.Struct },
-		MembersMock: func() []xmlrpc.Member { return members },
+		MembersMock: func() []xmlrpc.Member { return m },
 	}
 }

--- a/mock/value.go
+++ b/mock/value.go
@@ -27,65 +27,61 @@ func (m *Value) String() string           { return m.StringMock() }
 func (m *Value) Members() []xmlrpc.Member { return m.MembersMock() }
 func (m *Value) Kind() xmlrpc.Kind        { return m.KindMock() }
 
-func ValueReturningValues(actual ...xmlrpc.Value) *Value {
-	return &Value{
-		KindMock:   func() xmlrpc.Kind { return xmlrpc.Array },
-		ValuesMock: func() []xmlrpc.Value { return actual },
-	}
+func (m *Value) WithValues(actual ...xmlrpc.Value) *Value {
+	m.KindMock = func() xmlrpc.Kind { return xmlrpc.Array }
+	m.ValuesMock = func() []xmlrpc.Value { return actual }
+	return m
 }
 
-func ValueReturningBytes(actual []byte) *Value {
-	return &Value{
-		KindMock:  func() xmlrpc.Kind { return xmlrpc.Base64 },
-		BytesMock: func() []byte { return actual },
-	}
+func (m *Value) WithBytes(actual []byte) *Value {
+	m.KindMock = func() xmlrpc.Kind { return xmlrpc.Base64 }
+	m.BytesMock = func() []byte { return actual }
+	return m
 }
 
-func ValueReturningBool(actual bool) *Value {
-	return &Value{
-		KindMock: func() xmlrpc.Kind { return xmlrpc.Bool },
-		BoolMock: func() bool { return actual },
-	}
+func (m *Value) WithBool(actual bool) *Value {
+	m.KindMock = func() xmlrpc.Kind { return xmlrpc.Bool }
+	m.BoolMock = func() bool { return actual }
+	return m
 }
 
-func ValueReturningTime(actual time.Time) *Value {
-	return &Value{
-		KindMock: func() xmlrpc.Kind { return xmlrpc.DateTime },
-		TimeMock: func() time.Time { return actual },
-	}
+func (m *Value) WithTime(actual time.Time) *Value {
+	m.KindMock = func() xmlrpc.Kind { return xmlrpc.DateTime }
+	m.TimeMock = func() time.Time { return actual }
+	return m
 }
 
-func ValueReturningDouble(actual float64) *Value {
-	return &Value{
-		KindMock:   func() xmlrpc.Kind { return xmlrpc.Double },
-		DoubleMock: func() float64 { return actual },
-	}
+func (m *Value) WithDouble(actual float64) *Value {
+	m.KindMock = func() xmlrpc.Kind { return xmlrpc.Double }
+	m.DoubleMock = func() float64 { return actual }
+	return m
 }
 
-func ValueReturningInt(actual int) *Value {
-	return &Value{
-		KindMock: func() xmlrpc.Kind { return xmlrpc.Int },
-		IntMock:  func() int { return actual },
-	}
+func (m *Value) WithInt(actual int) *Value {
+	m.KindMock = func() xmlrpc.Kind { return xmlrpc.Int }
+	m.IntMock = func() int { return actual }
+	return m
 }
 
-func ValueReturningString(actual string) *Value {
-	return &Value{
-		KindMock:   func() xmlrpc.Kind { return xmlrpc.String },
-		StringMock: func() string { return actual },
-	}
+func (m *Value) WithString(actual string) *Value {
+	m.KindMock = func() xmlrpc.Kind { return xmlrpc.String }
+	m.StringMock = func() string { return actual }
+	return m
 }
 
-func ValueReturningMembers(actual map[string]xmlrpc.Value) *Value {
-	m := make([]xmlrpc.Member, 0)
-	for n, v := range actual {
+func (m *Value) WithMembers(actual map[string]xmlrpc.Value) *Value {
+	m.KindMock = func() xmlrpc.Kind { return xmlrpc.Struct }
+	m.MembersMock = func() []xmlrpc.Member { return m.membersFromMap(actual) }
+	return m
+}
+
+func (Value) membersFromMap(vs map[string]xmlrpc.Value) []xmlrpc.Member {
+	m := make([]xmlrpc.Member, len(vs))
+	for n, v := range vs {
 		m = append(m, &Member{
 			NameMock:  func() string { return n },
 			ValueMock: func() xmlrpc.Value { return v },
 		})
 	}
-	return &Value{
-		KindMock:    func() xmlrpc.Kind { return xmlrpc.Struct },
-		MembersMock: func() []xmlrpc.Member { return m },
-	}
+	return m
 }

--- a/mock/value_test.go
+++ b/mock/value_test.go
@@ -1,0 +1,300 @@
+package mock_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/SHyx0rmZ/go-xmlrpc"
+	"github.com/SHyx0rmZ/go-xmlrpc/mock"
+	"time"
+)
+
+var _ = Describe("mock Value", func() {
+	var (
+		value *mock.Value
+	)
+
+	BeforeEach(func() {
+		value = mock.NewValue()
+	})
+
+	Context("if unmodified", func() {
+		It("returns an invalid Kind", func() {
+			Expect(value.Kind()).To(Equal(xmlrpc.Invalid))
+		})
+	})
+
+	Context("if modified", func() {
+		Context("setting func", func() {
+			Context("ValuesMock", func() {
+				It("calls the ValuesMock", func() {
+					value1 := mock.NewValue()
+					value2 := mock.NewValue()
+
+					Expect(value1).ToNot(BeIdenticalTo(value2))
+
+					value.ValuesMock = func() []xmlrpc.Value {
+						return []xmlrpc.Value{
+							value1,
+							value2,
+						}
+					}
+
+					Expect(value.Values()).To(HaveLen(2))
+					Expect(value.Values()).To(ContainElement(value1))
+					Expect(value.Values()).To(ContainElement(value2))
+				})
+
+				It("returns an invalid kind", func() {
+					value.ValuesMock = func() []xmlrpc.Value {
+						return []xmlrpc.Value{
+							mock.NewValue(),
+							mock.NewValue(),
+						}
+					}
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Invalid))
+				})
+			})
+
+			Context("BytesMock", func() {
+				It("calls the BytesMock", func() {
+					bytes := []byte(`test-bytes`)
+
+					value.BytesMock = func() []byte {
+						return bytes
+					}
+
+					Expect(value.Bytes()).To(Equal(bytes))
+				})
+
+				It("returns an invalid Kind", func() {
+					value.BytesMock = func() []byte {
+						return []byte(`test-bytes`)
+					}
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Invalid))
+				})
+			})
+
+			Context("BoolMock", func() {
+				It("calls the BoolMock", func() {
+					value.BoolMock = func() bool {
+						return true
+					}
+
+					Expect(value.Bool()).To(Equal(true))
+				})
+
+				It("returns an invalid Kind", func() {
+					value.BoolMock = func() bool {
+						return true
+					}
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Invalid))
+				})
+			})
+
+			Context("TimeMock", func() {
+				It("calls the TimeMock", func() {
+					now := time.Now()
+
+					value.TimeMock = func() time.Time {
+						return now
+					}
+
+					Expect(value.Time()).To(BeIdenticalTo(now))
+				})
+
+				It("returns an invalid Kind", func() {
+					value.TimeMock = func() time.Time {
+						return time.Now()
+					}
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Invalid))
+				})
+			})
+
+			Context("DoubleMock", func() {
+				It("calls the DoubleMock", func() {
+					value.DoubleMock = func() float64 {
+						return 13.37
+					}
+
+					Expect(value.Double()).To(Equal(13.37))
+				})
+
+				It("returns an invalid Kind", func() {
+					value.DoubleMock = func() float64 {
+						return 13.37
+					}
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Invalid))
+				})
+			})
+
+			Context("IntMock", func() {
+				It("calls the IntMock", func() {
+					value.IntMock = func() int {
+						return 42
+					}
+
+					Expect(value.Int()).To(Equal(42))
+				})
+
+				It("returns an invalid Kind", func() {
+					value.IntMock = func() int {
+						return 42
+					}
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Invalid))
+				})
+			})
+
+			Context("StringMock", func() {
+				It("calls the StringMock", func() {
+					value.StringMock = func() string {
+						return "test-string"
+					}
+
+					Expect(value.String()).To(Equal("test-string"))
+				})
+
+				It("returns an invalid Kind", func() {
+					value.StringMock = func() string {
+						return "test-string"
+					}
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Invalid))
+				})
+			})
+
+			Context("MembersMock", func() {
+				It("calls the MembersMock", func() {
+					members := []xmlrpc.Member{
+						mock.NewMember().WithName("foo").WithValue(mock.NewValue()),
+						mock.NewMember().WithName("bar").WithValue(mock.NewValue()),
+					}
+
+					value.MembersMock = func() []xmlrpc.Member {
+						return members
+					}
+
+					Expect(value.Members()).To(HaveLen(2))
+					Expect(value.Members()).To(Equal(members))
+				})
+
+				It("returns an invalid Kind", func() {
+					value.MembersMock = func() []xmlrpc.Member {
+						return []xmlrpc.Member{
+							mock.NewMember().WithName("foo").WithValue(mock.NewValue()),
+							mock.NewMember().WithName("bar").WithValue(mock.NewValue()),
+						}
+					}
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Invalid))
+				})
+			})
+		})
+
+		Context("using method", func() {
+			Context("WithValues", func() {
+				It("returns Values", func() {
+					value1 := mock.NewValue()
+					value2 := mock.NewValue()
+
+					Expect(value1).ToNot(BeIdenticalTo(value2))
+
+					value.WithValues(value1, value2)
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Array))
+					Expect(value.Values()).To(HaveLen(2))
+					Expect(value.Values()).To(ContainElement(value1))
+					Expect(value.Values()).To(ContainElement(value2))
+				})
+			})
+
+			Context("WithBytes", func() {
+				It("returns Bytes", func() {
+					bytes := []byte(`test-bytes`)
+
+					value.WithBytes(bytes)
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Base64))
+					Expect(value.Bytes()).To(Equal(bytes))
+				})
+			})
+
+			Context("WithBool", func() {
+				It("returns Bool", func() {
+					value.WithBool(true)
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Bool))
+					Expect(value.Bool()).To(Equal(true))
+				})
+			})
+
+			Context("WithTime", func() {
+				It("returns Time", func() {
+					now := time.Now()
+
+					value.WithTime(now)
+
+					Expect(value.Kind()).To(Equal(xmlrpc.DateTime))
+					Expect(value.Time()).To(BeIdenticalTo(now))
+				})
+			})
+
+			Context("WithDouble", func() {
+				It("returns Double", func() {
+					value.WithDouble(13.37)
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Double))
+					Expect(value.Double()).To(Equal(13.37))
+				})
+			})
+
+			Context("WithInt", func() {
+				It("returns Int", func() {
+					value.WithInt(42)
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Int))
+					Expect(value.Int()).To(Equal(42))
+				})
+			})
+
+			Context("WithString", func() {
+				It("returns String", func() {
+					value.WithString("test-string")
+
+					Expect(value.Kind()).To(Equal(xmlrpc.String))
+					Expect(value.String()).To(Equal("test-string"))
+				})
+			})
+
+			Context("WithMembers", func() {
+				It("returns Members", func() {
+					members := map[string]xmlrpc.Value{
+						"foo": mock.NewValue(),
+						"bar": mock.NewValue(),
+					}
+
+					value.WithMembers(members)
+
+					Expect(value.Kind()).To(Equal(xmlrpc.Struct))
+					Expect(value.Members()).To(HaveLen(2))
+					Expect(value.Members()).To(ConsistOf(
+						SatisfyAll(
+							WithTransform((*mock.Member).Name, Equal("foo")),
+							WithTransform((*mock.Member).Value, Equal(members["foo"])),
+						),
+						SatisfyAll(
+							WithTransform((*mock.Member).Name, Equal("bar")),
+							WithTransform((*mock.Member).Value, Equal(members["bar"])),
+						),
+					))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
This adds a new package called "mock", which provides implementations of the `Client`, `Value` and `Member` interfaces, that can be used in tests.